### PR TITLE
Add Java 9 and BSD category

### DIFF
--- a/routes/submitData.js
+++ b/routes/submitData.js
@@ -128,6 +128,9 @@ router.post('/:software?', function(request, response, next) {
                         } else if (osName.startsWith("Mac OS X")) {
                             operatingSystemChart.data.values['Mac OS X'] = {};
                             operatingSystemChart.data.values['Mac OS X']['Mac OS X ' + osVersion] = 1;
+                        } else if (osName.indexOf("BSD") !== -1) {
+                            operatingSystemChart.data.values['BSD'] = {};
+                            operatingSystemChart.data.values['BSD'][osName] = 1;
                         } else {
                             operatingSystemChart.data.values['Other'] = {};
                             operatingSystemChart.data.values['Other'][osName + ' (' + osVersion + ')'] = 1;
@@ -153,6 +156,11 @@ router.post('/:software?', function(request, response, next) {
                         } else if (javaVersion.startsWith("1.8")) {
                             javaVersionChart.data.values['Java 1.8'] = {};
                             javaVersionChart.data.values['Java 1.8'][javaVersion] = 1;
+                        } else if (javaVersion.startsWith("9") || javaVersion === "1.9.0-ea") {
+                            //java 9 changed the version format to 9.0.1 and 1.9.0 is only used for early access
+                            //reference: http://openjdk.java.net/jeps/223
+                            javaVersionChart.data.values['Java 1.9'] = {};
+                            javaVersionChart.data.values['Java 1.9'][javaVersion] = 1;
                         } else {
                             javaVersionChart.data.values['Other'] = {};
                             javaVersionChart.data.values['Other'][javaVersion] = 1;


### PR DESCRIPTION
With the official release of Java 9 a couple of days ago, we should add it to the list of java versions besides Java 7 and 8 (currently only 0,1% in others).

BSD only has a usage of 0,1% or a total of 42 servers, but it's in my opinion something that should be mentioned just like Windows, Linux and Mac OS X. 

Although different BSD derivatives (GhostBSD, FreeBSD, OpenBSD, ...) do not share the same kernel (unlike Linux), I think it's ok to list it under same BSD category, because they have such a minor usage.

**Feedback required**: I removed the os version for BSD, because of the different results for FreeBSD like:

11.0-RELEASE
11.0-BETA
11.0-RELEASE-p9

Maybe we should ignore everything behind '-'?