### PR TITLE
Some improvements

### DIFF
--- a/views/plugin.ejs
+++ b/views/plugin.ejs
@@ -40,8 +40,7 @@
                 <% } %>
             </h1>
             <div class="row center">
-                <h5 class="header col s12 light authorbox">Author: <%= plugin.owner %></h5>
-                <h5 class="header col s12 light">Here are some stats about <%= plugin.name %></h5>
+                <h5 class="header col s12 light authorbox">by <%= plugin.owner %></h5>
             </div>
         </div>
     </div>

--- a/views/plugin.ejs
+++ b/views/plugin.ejs
@@ -40,9 +40,8 @@
                 <% } %>
             </h1>
             <div class="row center">
-                <h5 class="header col s12 light">Here are some stats about
-                    <div class="truncate"><%= plugin.name %></div>
-                </h5>
+                <h5 class="header col s12 light authorbox">Author: <%= plugin.owner %></h5>
+                <h5 class="header col s12 light">Here are some stats about <%= plugin.name %></h5>
             </div>
         </div>
     </div>

--- a/views/templates/footer.ejs
+++ b/views/templates/footer.ejs
@@ -1,11 +1,11 @@
 <footer class="page-footer <%= customColor1 %> darken-2">
     <div class="container">
         <div class="row">
-            <div class="col l6 s12">
+            <div class="col l6 m4 s12">
                 <h5 class="white-text">About bStats</h5>
                 <p class="grey-text text-lighten-4">Made with ❤</p>
             </div>
-            <div class="col l3 s12">
+            <div class="col l3 m4 s12">
                 <h5 class="white-text">Useful links</h5>
                 <ul>
                     <li><a class="white-text" href="/getting-started">Getting Started</a></li>
@@ -23,7 +23,7 @@
                     <li><a class="white-text" href="#colorPickerModal">Change Color</a></li>
                 </ul>
             </div>
-            <div class="col l3 s12">
+            <div class="col l3 m4 s12">
                 <h5 class="white-text">Legal notices</h5>
                 <ul>
                     <li><a class="white-text" href="/imprint">Imprint</a></li>

--- a/views/templates/navigation.ejs
+++ b/views/templates/navigation.ejs
@@ -2,7 +2,7 @@
 <ul id="slide-out" class="side-nav">
     <li>
         <div class="userView" style="min-height: 176px">
-            <span class="background <%= customColor1 %> darken-3"></span>
+            <img class="background" src="/images/cover.jpg">
             <img class="circle" src="/images/steve.jpg">
             <% if (loggedIn) { %>
             <span class="white-text name"><%= user.username %></span>

--- a/views/templates/navigation.ejs
+++ b/views/templates/navigation.ejs
@@ -2,7 +2,7 @@
 <ul id="slide-out" class="side-nav">
     <li>
         <div class="userView" style="min-height: 176px">
-            <img class="background" src="/images/cover.jpg">
+            <span class="background <%= customColor1 %> darken-3"></span>
             <img class="circle" src="/images/steve.jpg">
             <% if (loggedIn) { %>
             <span class="white-text name"><%= user.username %></span>


### PR DESCRIPTION
This is a pull request for improve the design of bStats.

The plugin name is now on the same line of "Here are some stats about", issue #3
> @BtoBastian says that are some problems with mobile devices but there aren't because the plugin name is automatically pushed on a new line when resizing:
> ![Description resize](https://puu.sh/yjz2Y/de40119e55.gif)
> But if you really want to force it on a new line, you can insert a `min-width css`

<br>

Added an _author box_ below the plugin name (issue  #29):
![Author box](https://puu.sh/yjC2P/5490d4bd1e.png)
Feel free to style it like you prefer, there is the class `authorbox` for that ;)

<br>

Removed the amiss background of the user, now it's appropriate with the user style (issue #4):
![User background](https://puu.sh/yjBWL/4a3cdfe452.png)

<br>

Unfortunately, I really want some features like `edit`, `delete`, `change password` or `id name support` but I'm not able to handle that kind of database (never developed in JS).
