### PR TITLE
Recommend using the compile scope instead of artifactSet

### DIFF
--- a/views/static/includeMetrics.ejs
+++ b/views/static/includeMetrics.ejs
@@ -65,7 +65,7 @@
     &lt;plugin&gt;
       &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
       &lt;artifactId&gt;maven-shade-plugin&lt;/artifactId&gt;
-      &lt;version&gt;2.4&lt;/version&gt;
+      &lt;version&gt;3.1.0&lt;/version&gt;
       &lt;configuration&gt;
         &lt;relocations&gt;
           &lt;relocation&gt;
@@ -115,12 +115,14 @@
       &lt;groupId&gt;org.spigotmc&lt;/groupId&gt;
       &lt;artifactId&gt;spigot-api&lt;/artifactId&gt;
       &lt;version&gt;LATEST&lt;/version&gt;
+      &lt;scope&gt;provided&lt;/scope&gt;
     &lt;/dependency&gt;
     &lt;!-- bStats --&gt;
     &lt;dependency&gt;
       &lt;groupId&gt;org.bstats&lt;/groupId&gt;
       &lt;artifactId&gt;bstats-bukkit&lt;/artifactId&gt;
       &lt;version&gt;1.2&lt;/version&gt;
+      &lt;scope&gt;compile&lt;/scope&gt;
     &lt;/dependency&gt;
   &lt;/dependencies&gt;
 
@@ -129,14 +131,9 @@
       &lt;plugin&gt;
         &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
         &lt;artifactId&gt;maven-shade-plugin&lt;/artifactId&gt;
-        &lt;version&gt;2.4&lt;/version&gt;
+        &lt;version&gt;3.1.0&lt;/version&gt;
         &lt;configuration&gt;
           &lt;minimizeJar&gt;true&lt;/minimizeJar&gt;
-          &lt;artifactSet&gt;
-            &lt;includes&gt;
-              &lt;include&gt;org.bstats:*&lt;/include&gt;
-            &lt;/includes&gt;
-          &lt;/artifactSet&gt;
           &lt;relocations&gt;
             &lt;relocation&gt;
               &lt;pattern&gt;org.bstats&lt;/pattern&gt;

--- a/views/static/includeMetrics.ejs
+++ b/views/static/includeMetrics.ejs
@@ -54,6 +54,7 @@
   &lt;groupId&gt;org.bstats&lt;/groupId&gt;
   &lt;artifactId&gt;bstats-bukkit&lt;/artifactId&gt;
   &lt;version&gt;1.2&lt;/version&gt;
+  &lt;scope&gt;compile&lt;/scope&gt;
 &lt;/dependency&gt;</code></pre>
                                     <b>3. Shade bStats into your plugin.</b><br>
                                     This step is very important. Shading means, that the necessary classes are copied into
@@ -66,11 +67,6 @@
       &lt;artifactId&gt;maven-shade-plugin&lt;/artifactId&gt;
       &lt;version&gt;2.4&lt;/version&gt;
       &lt;configuration&gt;
-        &lt;artifactSet&gt;
-          &lt;includes&gt;
-            &lt;include&gt;org.bstats:*&lt;/include&gt;
-          &lt;/includes&gt;
-        &lt;/artifactSet&gt;
         &lt;relocations&gt;
           &lt;relocation&gt;
             &lt;pattern&gt;org.bstats&lt;/pattern&gt;


### PR DESCRIPTION
Scopes are just way more reliable than artifact sets, and easier to setup. This setup works in my plugin. Correct me if there's a reason that artifactSet is used.

P.S. I hope I edited this right, never worked with .ejs files before

EDIT1: Also bumped the maven-shade-version to 3.1.0