### PR TITLE
Replace bcrypt-nodejs with bcrypt.js (#36)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "async-waterfall": "^0.1.5",
-    "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "2.4.3",
     "body-parser": "~1.17.1",
     "cluster": "^0.7.7",
     "connect-redis": "^3.3.2",

--- a/util/auth.js
+++ b/util/auth.js
@@ -1,7 +1,7 @@
 // load all the things we need
 const LocalStrategy = require('passport-local').Strategy;
 const databaseManager = require('./databaseManager');
-const bcrypt = require('bcrypt-nodejs');
+const bcrypt = require('bcryptjs');
 const saltRounds = 10;
 
 module.exports = function (passport) {


### PR DESCRIPTION
bcrypt.js is a drop-in replacement for bcrypt-nodejs.
I've tested logins and registrations, and they work fine.
The only noticeable difference seems to be that hashes are generated differently.

 